### PR TITLE
Literalize `$text_domain` parameter in all gettext functions.

### DIFF
--- a/includes/class-knowledge-base-shortcode.php
+++ b/includes/class-knowledge-base-shortcode.php
@@ -83,7 +83,7 @@ class Knowledge_Base_Shortcode {
             'taxonomy'      => Knowledge_Base_Taxonomy::name,
             'show_count'    => 1,
             'walker'        => new Knowledge_Base_Walker_Class,
-            'title_li'      => __( '', Knowledge_Base::$text_domain ),
+            'title_li'      => __( '', 'knowledge-base' ),
             //'echo'          => 0
         ) );
         ?>

--- a/includes/class-knowledge-base-taxonomy.php
+++ b/includes/class-knowledge-base-taxonomy.php
@@ -33,8 +33,8 @@ class Knowledge_Base_Taxonomy {
      */
     public function __construct() {
         $this->labels = apply_filters( 'kb_category_taxonomy_labels', array(
-            'name'              => __( 'Categories', Knowledge_Base::$text_domain ),
-            'singular_name'     => _x( 'Category', 'taxonomy general name', Knowledge_Base::$text_domain ),
+            'name'              => __( 'Categories', 'knowledge-base' ),
+            'singular_name'     => _x( 'Category', 'taxonomy general name', 'knowledge-base' ),
         ) );
     }
 

--- a/includes/class-knowledge-base.php
+++ b/includes/class-knowledge-base.php
@@ -59,8 +59,8 @@ class Knowledge_Base_Entry {
      */
     public function __construct () {
         $this->labels = apply_filters( 'kb_post_type_labels', array(
-            'name'                  => _x( 'Knowledge Base', 'Post Type General Name', Knowledge_Base::$text_domain ),
-            'singular_name'         => _x( 'Knowledge Base Item', 'Post Type Singular Name', Knowledge_Base::$text_domain ),
+            'name'                  => _x( 'Knowledge Base', 'Post Type General Name', 'knowledge-base' ),
+            'singular_name'         => _x( 'Knowledge Base Item', 'Post Type Singular Name', 'knowledge-base' ),
         ) );
     }
 

--- a/knowledge-base.php
+++ b/knowledge-base.php
@@ -44,15 +44,6 @@ class Knowledge_Base {
     public static $prefix = 'Knowledge_Base';
 
     /**
-     * Text Domain
-     *
-     * @link https://codex.wordpress.org/I18n_for_WordPress_Developers#Text_Domains
-     *
-     * @var string
-     */
-    public static $text_domain = 'knowledge-base';
-
-    /**
      * Entry point for the WordPress framework into plugin code.
      *
      * This is the method called when WordPress loads the plugin file.
@@ -140,7 +131,7 @@ class Knowledge_Base {
         if (version_compare($min_wp_version, $wp_version) > 0) {
             deactivate_plugins(plugin_basename(__FILE__));
             wp_die(sprintf(
-                __('Knowledge_Base requires at least WordPress version %1$s. You have WordPress version %2$s.', 'Knowledge_Base'),
+                __('Knowledge_Base requires at least WordPress version %1$s. You have WordPress version %2$s.', 'knowledge-base'),
                 $min_wp_version, $wp_version
             ));
         }

--- a/languages/index.php
+++ b/languages/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden.


### PR DESCRIPTION
When internationalizing user interface text, the $text_domain parameter
must not be a variable. This is because the tools that parse plugin
source code in order to map the strings to the correct text domains do
not actually use PHP interpreters and can therefor not interpolate the
variable values to the correct string.

See also this warning:
https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains
